### PR TITLE
Fix for Coq 8.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 ## Description
 
-This is a plugin for Coq v8.5 that implements the call-by-name forcing translation.
+This is a plugin for Coq v8.6 that implements the call-by-name forcing translation.
 The translation is described in this [draft](https://www.xn--pdrot-bsa.fr/articles/draft-forcing.pdf).
 
 ## Install
 
-You need Coq v8.5 development files. The ```COQBIN``` environment variable
+You need Coq v8.6 development files. The ```COQBIN``` environment variable
 should be pointing to the Coq binaries folder. Echoing ```make``` should be
 enough then.
 

--- a/src/fTranslate.mli
+++ b/src/fTranslate.mli
@@ -20,4 +20,4 @@ val translate_type : ?toplevel:bool -> ?lift:int -> translator -> category ->
   Environ.env -> Evd.evar_map -> Constr.t -> Evd.evar_map * Constr.t
 
 val translate_context : ?toplevel:bool -> ?lift:int -> translator -> category ->
-  Environ.env -> Evd.evar_map -> Context.rel_context -> Evd.evar_map * Context.rel_context
+  Environ.env -> Evd.evar_map -> Context.Rel.t -> Evd.evar_map * Context.Rel.t

--- a/src/g_forcing.ml4
+++ b/src/g_forcing.ml4
@@ -1,3 +1,6 @@
+open Constrarg
+open Extraargs
+
 DECLARE PLUGIN "forcing"
 
 TACTIC EXTEND force


### PR DESCRIPTION
- need to open things in the ml4
- Context `LocalAssum`/`LocalDef` elements appeared
- some name changes (`Errors` -> `CErrors`, `Typing.check` -> `Typing.e_check`, `Pp.msg_info` -> `Feedback.msg_info`)
- `Proofview.Goal.nf_enter` takes a `Sigma` aware argument.