### PR TITLE
Fixing _CoqProject so that make install works.

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -1,5 +1,5 @@
--R theories/ Forcing
--I src/
+-R theories Forcing
+-I src
 
 src/fTranslate.ml
 src/fTranslate.mli


### PR DESCRIPTION
The `make install` target of `coq_makefile` does not like trailing `/` in `-R` options (at least in 8.6).