### PR TITLE
Ability to declare definition forced at specific object

### DIFF
--- a/src/fPlugin.mli
+++ b/src/fPlugin.mli
@@ -6,4 +6,4 @@ val force_tac : FTranslate.category -> Constr.t -> unit tactic
 
 val force_translate : (reference * reference) -> reference -> Id.t list option -> unit
 
-val force_implement : (reference * reference) -> Id.t -> Constrexpr.constr_expr -> Id.t option -> unit
+val force_implement : (reference * reference) -> Id.t -> Constrexpr.constr_expr -> Id.t option -> Constrexpr.constr_expr option -> unit

--- a/src/g_forcing.ml4
+++ b/src/g_forcing.ml4
@@ -24,7 +24,11 @@ let classify_impl _ = Vernacexpr.(VtStartProof ("Classic",Doesn'tGuaranteeOpacit
 
 VERNAC COMMAND EXTEND ForcingImplementation CLASSIFIED BY classify_impl
 | [ "Forcing" "Definition" ident(id) ":" lconstr(typ) "using" global(obj) global(hom) ] ->
-  [ FPlugin.force_implement (obj, hom) id typ None ]
-| [ "Forcing" "Definition" ident(id) ":" lconstr(typ) "as" ident(id') "using" global(obj) global(hom) ] ->
-  [ FPlugin.force_implement (obj, hom) id typ (Some id') ]
+  [ FPlugin.force_implement (obj, hom) id typ None None ]
+| [ "Forcing" "Definition" ident(id) ":" lconstr(typ) "as" ident(id') "using" global(obj) global(hom)] ->
+  [ FPlugin.force_implement (obj, hom) id typ (Some id') None ]
+| [ "Forcing" "Definition" ident(id) ":" lconstr(typ) "using" global(obj) global(hom) "from" constr(c)] ->
+  [ FPlugin.force_implement (obj, hom) id typ None (Some c) ]
+| [ "Forcing" "Definition" ident(id) ":" lconstr(typ) "as" ident(id') "using" global(obj) global(hom) "from" constr(c)] ->
+  [ FPlugin.force_implement (obj, hom) id typ (Some id') (Some c) ]
 END


### PR DESCRIPTION
For an application of coq-forcing plugin I'm working on with @herbelin, we needed a definition restricted at specific world.
I added the following syntax with an optional "from" clause :  
```
"Forcing" "Definition" ident(id) ":" lconstr(typ) "as" ident(id') "using" global(obj) global(hom) "from" constr(c)
```
It was useful for us and maybe it can be useful for others too.
We can give more details if you want.